### PR TITLE
adding MICRODATA_VOCABULARY settings, schema.org as the default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,12 @@ Microdata plugin provides two directives:
         :itemprop:`Displayed text <itemprop name>`
         :itemprop:`Displayed text <itemprop name:http://some.url/>`
 
+Settings
+~~~~~~~~
+
+You can define a vocabulary to use.
+
+If not set, `schema.org <http://schema.org>` is the default value.
 
 Example
 ~~~~~~~
@@ -73,7 +79,7 @@ This reStructuredText document:
 
 .. code-block:: ReST
 
-    .. itemscope: Person
+    .. itemscope:: Person
         :tag: p
 
         My name is :itemprop:`Bob Smith <name>`

--- a/microdata/plugin.py
+++ b/microdata/plugin.py
@@ -39,7 +39,7 @@ will result in:
 
 .. code-block:: html
 
-    <p itemscope itemtype="http://data-vocabulary.org/Person">
+    <p itemscope itemtype="http://schema.org/Person">
         My name is <span itemprop="name">Bob Smith</span>
         but people call me <span itemprop="nickname">Smithy</span>.
         Here is my home page:
@@ -59,6 +59,11 @@ from docutils.parsers.rst import directives, Directive, roles
 from pelican.readers import PelicanHTMLTranslator
 from types import MethodType
 
+import pelican
+if pelican.settings.get_settings_from_file("pelicanconf.py").get("MICRODATA_VOCABULARY"):
+    MICRODATA_VOCABULARY_PREFIX = pelican.settings.get_settings_from_file("pelicanconf.py").get("MICRODATA_VOCABULARY")
+else:
+    MICRODATA_VOCABULARY_PREFIX = "http://schema.org"
 
 RE_ROLE = re.compile(r'(?P<value>.+?)\s*\<(?P<name>.+)\>')
 
@@ -84,13 +89,13 @@ class ItemScope(nodes.Element):
     def __init__(self, tagname, itemtype, itemprop=None, compact=False):
         kwargs = {
             'itemscope': None,
-            'itemtype': "http://data-vocabulary.org/%s" % itemtype,
+            'itemtype': "%s/%s" % (MICRODATA_VOCABULARY_PREFIX, itemtype),
         }
         if itemprop:
             kwargs['itemprop'] = itemprop
         super(ItemScope, self).__init__('', **kwargs)
         self.tagname = tagname
-        self.compact =  tagname == 'p' or compact
+        self.compact = tagname == 'p' or compact
 
 
 class ItemScopeDirective(Directive):


### PR DESCRIPTION
It would be good to make things flexible.
For example, I wanted to use schema.org as my vocabulary,
as search engines are able to read it.

Schema.org is the default here because is the most used vocabulary.
